### PR TITLE
Improved answer to more natural language.

### DIFF
--- a/instruction_datasets/swiss_criticality_prediction.py
+++ b/instruction_datasets/swiss_criticality_prediction.py
@@ -15,16 +15,24 @@ class SwissCriticalityPrediction(AbstractDataset):
             "SwissCriticalityPrediction",
             "https://huggingface.co/datasets/rcds/swiss_criticality_prediction")
 
+    
+
     def get_data(self, instructions: instruction_manager.InstructionManager):
         task_type = TaskType.TEXT_CLASSIFICATION
         jurisdiction = Jurisdiction.SWITZERLAND
         answer_language = "en"
 
+        label_mapping = {'critical-4': 'This case is extremely critical.', 
+                         'critical-3': 'This case is very critical.', 
+                         'critical-2': 'This case is moderately critical.', 
+                         'critical-1': 'This case is somewhat critical.',
+                         'non-critical': 'This case is non critical.'}
+
         df = load_dataset('rcds/swiss_criticality_prediction', 'full', split='train')
         for example in df:
             subset = "swiss_judgment_criticality"
             instruction, instruction_language = instructions.sample(subset)
-            answer = f"Criticality: {example['citation_label']}"
+            answer = f"{label_mapping[example['citation_label']]}"
 
             if len(example['facts']) > 100:
                 prompt = f"Facts: {example['facts']}"

--- a/instruction_prompts/en.json
+++ b/instruction_prompts/en.json
@@ -1012,16 +1012,16 @@
       "Explain the court's stance (considerations) based on the provided facts and lower court's considerations."
     ],
     "swiss_judgment_criticality": [
-      "How important or critical is this case? The case can be non-critical or range from critical-1 (least critical) to critical-4 (most critical).",
-      "Determine the level of importance or criticality of this case, with non-critical being the lowest and critical-4 being the highest.",
-      "Assess the criticality of this case on a scale of non-critical to critical-4, with critical-4 being the most critical.",
-      "Rate the importance or criticality of this case, from non-critical to critical-4, where critical-4 represents the highest level of criticality.",
-      "Evaluate the significance or criticality of this case, with options ranging from non-critical to critical-4 (most critical).",
-      "Gauge the level of criticality of this case, with non-critical at the low end and critical-4 at the high end.",
-      "Estimate the importance or criticality of this case, with levels ranging from non-critical to critical-4 (most critical).",
-      "Rank the criticality of this case on a scale from non-critical to critical-4, where critical-4 is the most critical.",
-      "Deduce the level of importance or criticality for this case, with options from non-critical to critical-4 (most critical).",
-      "Decide on the criticality of this case, with a range of non-critical to critical-4, where critical-4 is the highest level of criticality."
+      "How important or critical is this case?",
+      "Determine the level of importance or criticality of this case.",
+      "Assess the criticality of this case.",
+      "Rate the importance or criticality of this case.",
+      "Evaluate the significance or criticality of this case.",
+      "Gauge the level of criticality of this case.",
+      "Estimate the importance or criticality of this case.",
+      "Rank the criticality of this case.",
+      "Deduce the level of importance or criticality for this case.",
+      "Decide on the criticality of this case."
     ],
     "swiss_judgment_dismiss_approve": [
       "Determine if the Swiss court will dismiss or approve the case.",


### PR DESCRIPTION
As requested I looked for answers that require improvements to more natural languague among the swiss instruction datasets. This is the only one where I feel that an improvement was really necessary. 

Is this how you imagined it?

```
{"dataset_name": "SwissCriticalityPrediction", "subset_name": "swiss_judgment_criticality", "source": "https://huggingface.co/datasets/rcds/swiss_criticality_prediction", "instruction_language": "en", "prompt_language": "fr", "answer_language": "en", "jurisdiction": "SWITZERLAND", "task_type": "TEXT_CLASSIFICATION", "downloaded_timestamp": "07-12-2024", "instruction": "How important or critical is this case?", "prompt": "Facts: Faits:\nA. Consid\u00e9rant qu'il se trouvait dans l'impossibilit\u00e9 de respecter les prescriptions relatives au travail du dimanche pour certains de ses services, l'A\u00e9roport International de Gen\u00e8ve (ci-apr\u00e8s l'A\u00e9roport) a d\u00e9pos\u00e9, le 28 octobre 2010, une demande aupr\u00e8s du Secr\u00e9tariat d'\u00c9tat \u00e0 l'\u00e9conomie (ci-apr\u00e8s Seco) tendant \u00e0 d\u00e9roger \u00e0 la l\u00e9gislation sur le travail et visant \u00e0 faire passer de 26 \u00e0 20 le nombre minimal de dimanches de cong\u00e9 pour une partie du personnel au sol du secteur de la navigation a\u00e9rienne, avec effet au 1er janvier 2011.\nB. Par d\u00e9cision du 25 f\u00e9vrier 2011 (FF 2011 2166), le Seco a accord\u00e9 \u00e0 l'A\u00e9roport une d\u00e9rogation valable du 1er janvier 2011 au 31 d\u00e9cembre 2013. Selon celle-ci, le personnel au sol du secteur de la navigation a\u00e9rienne travaillant aupr\u00e8s des services \"s\u00fbret\u00e9 passagers, AAU (plans de vols et informations aux pilotes), AMS (guidage au sol des a\u00e9ronefs), APS (positionnement des a\u00e9ronefs au sol), Piste (transport des passagers et conduites des v\u00e9hicules destin\u00e9s \u00e0 guider des a\u00e9ronefs sur la piste) et SSA (section feu, surveillance, transmissions)\" b\u00e9n\u00e9ficiait d'au moins 20 dimanches de cong\u00e9 par ann\u00e9e civile pouvant \u00eatre r\u00e9partis \u00e0 intervalles irr\u00e9guliers sur l'ann\u00e9e. En contrepartie, une compensation de 25 % de la dur\u00e9e du travail effectu\u00e9 pendant la p\u00e9riode du dimanche d\u00e8s le 23\u00e8me dimanche travaill\u00e9 dans l'ann\u00e9e \u00e9tait pr\u00e9vue.\nA l'encontre de cette d\u00e9cision, le Syndicat suisse des services publics (ci-apr\u00e8s le SSP) et A._ ont recouru conjointement aupr\u00e8s du Tribunal administratif f\u00e9d\u00e9ral. Apr\u00e8s avoir retir\u00e9 l'effet suspensif, cette instance a, par arr\u00eat du 22 d\u00e9cembre 2011, admis le recours et annul\u00e9 la d\u00e9cision attaqu\u00e9e.\nC. Contre l'arr\u00eat du Tribunal administratif f\u00e9d\u00e9ral du 22 d\u00e9cembre 2011, l'A\u00e9roport forme un recours en mati\u00e8re de droit public au Tribunal f\u00e9d\u00e9ral. Il conclut, sous suite de frais et d\u00e9pens, \u00e0 l'admission du recours, \u00e0 l'annulation de l'arr\u00eat attaqu\u00e9 et \u00e0 la confirmation de la d\u00e9cision du Seco du 25 f\u00e9vrier 2011 accordant la d\u00e9rogation requise.\nA._ et le SSP proposent le rejet du recours, sous suite de frais et d\u00e9pens. Le Tribunal administratif f\u00e9d\u00e9ral a renonc\u00e9 \u00e0 prendre position, renvoyant aux consid\u00e9rants de l'arr\u00eat attaqu\u00e9. Le Seco n'a pas d\u00e9pos\u00e9 d'observations.\nPar ordonnance du 8 mars 2012, le Pr\u00e9sident de la IIe Cour de droit public a accord\u00e9 l'effet suspensif au recours.\nLe 26 octobre 2012, la Cour de c\u00e9ans a d\u00e9lib\u00e9r\u00e9 sur le pr\u00e9sent recours en s\u00e9ance publique.", "answer": "This case is somewhat critical."}
```